### PR TITLE
Add backend persistence for map labels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+*.pyc
+node_modules/
+data/labels.db
+data/server.log

--- a/README.md
+++ b/README.md
@@ -1,0 +1,24 @@
+# Hex Labeler with Sync Backend
+
+This project provides the single-page hex map labeler along with a lightweight
+Python backend that persists map labels to an SQLite database. Running the
+server allows multiple clients to share the same map ID and automatically keep
+their labels synchronized.
+
+## Running the server
+
+```bash
+python server.py
+```
+
+The server listens on port 8000 by default. Once it is running, open the
+`hex_labeler_webapp_single_file_html_js.html` file through the server:
+
+```
+http://localhost:8000/hex_labeler_webapp_single_file_html_js.html
+```
+
+Labels are stored in `data/labels.db`. Every change in the UI is saved locally
+(in `localStorage`) and also queued for synchronization with the backend. When
+you load a map ID, the application first tries to fetch the latest copy from
+the server and falls back to the local cache if the server is unavailable.

--- a/data/.gitignore
+++ b/data/.gitignore
@@ -1,0 +1,3 @@
+# Keep the data directory but ignore generated database/log files.
+*
+!.gitignore

--- a/hex_labeler_webapp_single_file_html_js.html
+++ b/hex_labeler_webapp_single_file_html_js.html
@@ -130,24 +130,113 @@
   <script>
     // --- Utility: localStorage persistence
     const storageKey = (id) => `hexlabeler:${id}`;
+    const remoteSync = createRemoteSync();
+
+    function saveStateLocal(id, data) {
+      try {
+        localStorage.setItem(storageKey(id), JSON.stringify(data));
+      } catch (err) {
+        console.warn('Failed to persist state locally', err);
+      }
+    }
+
+    function loadStateLocal(id) {
+      const raw = localStorage.getItem(storageKey(id));
+      if (!raw) return null;
+      try {
+        return JSON.parse(raw);
+      } catch (err) {
+        console.warn('Failed to parse saved state', err);
+        return null;
+      }
+    }
+
+    async function applyLoadedState(state, id) {
+      labels = Array.isArray(state.labels) ? state.labels : [];
+      applyOptions(state.options || {});
+      const desiredImage = state.imgMeta?.src;
+      if (desiredImage && desiredImage !== mapImg.src) {
+        try {
+          await setImage(desiredImage);
+        } catch (err) {
+          console.warn('Failed to load remote image, continuing with current map', err);
+          draw();
+        }
+      } else {
+        draw();
+      }
+      const snapshot = {
+        labels,
+        options: currentOptions(),
+        imgMeta: state.imgMeta || currentImageMeta()
+      };
+      saveStateLocal(id, snapshot);
+    }
+
+    async function loadState({ preferRemote = true } = {}) {
+      const id = mapId.value.trim() || 'default';
+      if (preferRemote) {
+        const remote = await remoteSync.load(id);
+        if (remote) {
+          await applyLoadedState(remote, id);
+          return true;
+        }
+      }
+      const local = loadStateLocal(id);
+      if (local) {
+        await applyLoadedState(local, id);
+        return true;
+      }
+      labels = [];
+      draw();
+      return false;
+    }
 
     function saveState() {
       const id = mapId.value.trim() || 'default';
       const data = { labels, options: currentOptions(), imgMeta: currentImageMeta() };
-      localStorage.setItem(storageKey(id), JSON.stringify(data));
+      saveStateLocal(id, data);
+      remoteSync.queueSave(id, data);
     }
 
-    function loadState() {
-      const id = mapId.value.trim() || 'default';
-      const raw = localStorage.getItem(storageKey(id));
-      if (!raw) return false;
-      try {
-        const obj = JSON.parse(raw);
-        labels = obj.labels || [];
-        applyOptions(obj.options || {});
-        draw();
-        return true;
-      } catch { return false; }
+    function createRemoteSync() {
+      let pending = null;
+      let timer = null;
+
+      async function pushUpdate() {
+        if (!pending) return;
+        const { id, payload } = pending;
+        pending = null;
+        timer = null;
+        try {
+          await fetch(`/api/maps/${encodeURIComponent(id)}`, {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(payload)
+          });
+        } catch (err) {
+          console.warn('Failed to sync map to server', err);
+        }
+      }
+
+      return {
+        queueSave(id, payload) {
+          pending = { id, payload };
+          if (timer) clearTimeout(timer);
+          timer = setTimeout(pushUpdate, 600);
+        },
+        async load(id) {
+          try {
+            const res = await fetch(`/api/maps/${encodeURIComponent(id)}`);
+            if (res.status === 404) return null;
+            if (!res.ok) throw new Error(`Server responded with ${res.status}`);
+            return await res.json();
+          } catch (err) {
+            console.warn('Failed to load map from server', err);
+            return null;
+          }
+        }
+      };
     }
 
     function currentImageMeta() {
@@ -371,9 +460,13 @@
     });
 
     // Persist UI -> redraw
-    [mapId].forEach(inp => {
-      inp.addEventListener('input', () => { draw(); saveState(); });
-      inp.addEventListener('change', () => { draw(); saveState(); });
+    mapId.addEventListener('change', async () => {
+      const found = await loadState({ preferRemote: true });
+      if (!found) {
+        labels = [];
+        draw();
+        saveState();
+      }
     });
 
     // Initial image: try to preload the provided path if available
@@ -386,7 +479,10 @@
         console.warn('Failed to load bundled map image:', err);
       }
       // Attempt to load any saved state for default project
-      loadState();
+      const loaded = await loadState({ preferRemote: true });
+      if (!loaded) {
+        saveState();
+      }
     })();
 
     // --- Grid analysis

--- a/server.py
+++ b/server.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+import json
+import os
+import sqlite3
+import threading
+from datetime import datetime, timezone
+from http import HTTPStatus
+from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from urllib.parse import urlparse, unquote
+
+ROOT = Path(__file__).resolve().parent
+DATA_DIR = ROOT / "data"
+DATA_DIR.mkdir(parents=True, exist_ok=True)
+DB_PATH = DATA_DIR / "labels.db"
+
+DB_LOCK = threading.Lock()
+DB_CONN = sqlite3.connect(DB_PATH, check_same_thread=False)
+DB_CONN.execute(
+    """
+    CREATE TABLE IF NOT EXISTS maps (
+        id TEXT PRIMARY KEY,
+        labels TEXT NOT NULL,
+        options TEXT,
+        img_meta TEXT,
+        updated_at TEXT NOT NULL
+    )
+    """
+)
+DB_CONN.commit()
+
+
+def _json_dump(value):
+    return json.dumps(value, ensure_ascii=False, separators=(",", ":"))
+
+
+def _row_to_payload(row):
+    if not row:
+        return None
+    labels = json.loads(row[1]) if row[1] else []
+    options = json.loads(row[2]) if row[2] else {}
+    img_meta = json.loads(row[3]) if row[3] else None
+    return {
+        "mapId": row[0],
+        "labels": labels,
+        "options": options,
+        "imgMeta": img_meta,
+        "updatedAt": row[4],
+    }
+
+
+class HexLabelHandler(SimpleHTTPRequestHandler):
+    server_version = "HexLabelServer/1.0"
+
+    def do_GET(self):
+        parsed = urlparse(self.path)
+        if parsed.path.startswith("/api/maps/"):
+            map_id = unquote(parsed.path[len("/api/maps/"):])
+            if not map_id:
+                self.send_error(HTTPStatus.BAD_REQUEST, "Map ID required")
+                return
+            with DB_LOCK:
+                row = DB_CONN.execute(
+                    "SELECT id, labels, options, img_meta, updated_at FROM maps WHERE id = ?",
+                    (map_id,),
+                ).fetchone()
+            if not row:
+                self.send_error(HTTPStatus.NOT_FOUND, "Map not found")
+                return
+            payload = _row_to_payload(row)
+            body = _json_dump(payload).encode("utf-8")
+            self.send_response(HTTPStatus.OK)
+            self.send_header("Content-Type", "application/json; charset=utf-8")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+            return
+        return super().do_GET()
+
+    def do_PUT(self):
+        parsed = urlparse(self.path)
+        if not parsed.path.startswith("/api/maps/"):
+            self.send_error(HTTPStatus.NOT_FOUND, "Unknown endpoint")
+            return
+        map_id = unquote(parsed.path[len("/api/maps/"):])
+        if not map_id:
+            self.send_error(HTTPStatus.BAD_REQUEST, "Map ID required")
+            return
+        content_length = int(self.headers.get("Content-Length", "0"))
+        raw_body = self.rfile.read(content_length) if content_length else b""
+        try:
+            payload = json.loads(raw_body.decode("utf-8") or "{}")
+        except json.JSONDecodeError:
+            self.send_error(HTTPStatus.BAD_REQUEST, "Invalid JSON body")
+            return
+        labels = payload.get("labels")
+        options = payload.get("options", {})
+        img_meta = payload.get("imgMeta")
+        if not isinstance(labels, list):
+            self.send_error(HTTPStatus.BAD_REQUEST, "'labels' must be an array")
+            return
+        if not isinstance(options, dict):
+            self.send_error(HTTPStatus.BAD_REQUEST, "'options' must be an object")
+            return
+        timestamp = datetime.now(timezone.utc).isoformat()
+        labels_blob = _json_dump(labels)
+        options_blob = _json_dump(options)
+        img_blob = _json_dump(img_meta) if img_meta is not None else None
+        with DB_LOCK:
+            DB_CONN.execute(
+                """
+                INSERT INTO maps (id, labels, options, img_meta, updated_at)
+                VALUES (?, ?, ?, ?, ?)
+                ON CONFLICT(id) DO UPDATE SET
+                    labels = excluded.labels,
+                    options = excluded.options,
+                    img_meta = excluded.img_meta,
+                    updated_at = excluded.updated_at
+                """,
+                (map_id, labels_blob, options_blob, img_blob, timestamp),
+            )
+            DB_CONN.commit()
+        response = {"ok": True, "updatedAt": timestamp}
+        body = _json_dump(response).encode("utf-8")
+        self.send_response(HTTPStatus.OK)
+        self.send_header("Content-Type", "application/json; charset=utf-8")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, format, *args):
+        # Reduce default noisy logging, include timestamp.
+        message = "%s - - [%s] %s\n" % (
+            self.client_address[0],
+            self.log_date_time_string(),
+            format % args,
+        )
+        try:
+            self.server.log_stream.write(message)
+        except Exception:
+            pass
+
+
+class HexLabelServer(ThreadingHTTPServer):
+    def __init__(self, server_address, handler_class=HexLabelHandler):
+        super().__init__(server_address, handler_class)
+        self.log_stream = open(DATA_DIR / "server.log", "a", encoding="utf-8")
+
+    def server_close(self):
+        try:
+            self.log_stream.close()
+        finally:
+            super().server_close()
+
+
+def run(host="0.0.0.0", port=8000):
+    server = HexLabelServer((host, port))
+    print(f"Serving Hex Labeler on http://{host}:{port}")
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        print("\nShutting down server...")
+    finally:
+        server.server_close()
+        with DB_LOCK:
+            DB_CONN.close()
+
+
+if __name__ == "__main__":
+    port = int(os.environ.get("PORT", "8000"))
+    run(port=port)


### PR DESCRIPTION
## Summary
- add a lightweight Python HTTP server that stores map labels in an SQLite database and serves the static client
- enhance the client to sync label changes with the server while keeping localStorage fallback
- document how to run the server and ignore generated database/log artifacts

## Testing
- python -m py_compile server.py
- python server.py (terminated with Ctrl+C after verifying startup)


------
https://chatgpt.com/codex/tasks/task_e_68d5d9735a788324824c194568da18b3