### PR TITLE
Use Firebase for map persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Hex Labeler with Sync Backend
 
 This project provides the single-page hex map labeler along with a lightweight
-Python backend that persists map labels to an SQLite database. Running the
-server allows multiple clients to share the same map ID and automatically keep
-their labels synchronized.
+Python backend that persists map labels to a Google Firestore database. Running
+the server allows multiple clients to share the same map ID and automatically
+keep their labels synchronized across devices.
 
 ## Running the server
 
@@ -18,7 +18,19 @@ The server listens on port 8000 by default. Once it is running, open the
 http://localhost:8000/hex_labeler_webapp_single_file_html_js.html
 ```
 
-Labels are stored in `data/labels.db`. Every change in the UI is saved locally
-(in `localStorage`) and also queued for synchronization with the backend. When
-you load a map ID, the application first tries to fetch the latest copy from
-the server and falls back to the local cache if the server is unavailable.
+### Firebase configuration
+
+The server expects credentials for a Google Cloud project with Firestore
+enabled. Provide the path to a service account JSON key file via the
+`FIREBASE_CREDENTIALS` environment variable. If the variable is not provided the
+server will fall back to Application Default Credentials (ADC).
+
+```bash
+export FIREBASE_CREDENTIALS="/path/to/service-account.json"
+python server.py
+```
+
+Every change in the UI is saved locally (in `localStorage`) and also queued for
+synchronization with the backend. When you load a map ID, the application first
+tries to fetch the latest copy from the server and falls back to the local cache
+if the server is unavailable.

--- a/firebase_db.py
+++ b/firebase_db.py
@@ -1,0 +1,70 @@
+"""Firebase persistence helpers for the hex labeler server."""
+
+from __future__ import annotations
+
+import os
+import threading
+from typing import Any, Dict, Optional
+
+try:
+    from firebase_admin import credentials, firestore, get_app, initialize_app
+    from google.api_core.exceptions import GoogleAPIError
+except ModuleNotFoundError as exc:  # pragma: no cover - import guard
+    raise RuntimeError(
+        "The 'firebase_admin' package is required to use the Firebase backend."
+    ) from exc
+
+_CLIENT = None
+_INIT_LOCK = threading.Lock()
+
+
+def initialize() -> firestore.Client:
+    """Initialise and return a Firestore client."""
+    global _CLIENT
+    if _CLIENT is not None:
+        return _CLIENT
+    with _INIT_LOCK:
+        if _CLIENT is not None:
+            return _CLIENT
+        cred_path = os.environ.get("FIREBASE_CREDENTIALS")
+        if cred_path:
+            cred = credentials.Certificate(cred_path)
+            app = initialize_app(cred)
+        else:
+            try:
+                app = get_app()
+            except ValueError:
+                cred = credentials.ApplicationDefault()
+                app = initialize_app(cred)
+        _CLIENT = firestore.client(app)
+        return _CLIENT
+
+
+def get_map_record(map_id: str) -> Optional[Dict[str, Any]]:
+    """Fetch a map record from Firestore."""
+    client = initialize()
+    try:
+        doc = client.collection("maps").document(map_id).get()
+    except GoogleAPIError as exc:  # pragma: no cover - defensive logging
+        raise RuntimeError("Failed to fetch map from Firestore") from exc
+    if not doc.exists:
+        return None
+    data = doc.to_dict() or {}
+    data.setdefault("mapId", map_id)
+    return data
+
+
+def upsert_map_record(map_id: str, record: Dict[str, Any]) -> None:
+    """Create or update a map record in Firestore."""
+    client = initialize()
+    payload = {
+        "mapId": record.get("mapId", map_id),
+        "labels": record.get("labels", []),
+        "options": record.get("options", {}),
+        "imgMeta": record.get("imgMeta"),
+        "updatedAt": record.get("updatedAt"),
+    }
+    try:
+        client.collection("maps").document(map_id).set(payload)
+    except GoogleAPIError as exc:  # pragma: no cover - defensive logging
+        raise RuntimeError("Failed to update map in Firestore") from exc


### PR DESCRIPTION
## Summary
- replace the previous SQLite storage with Firebase-backed helpers and initialize Firestore on server startup
- update the HTTP handlers to read and write map payloads through the new Firebase layer
- document the Firebase configuration requirement and credentials setup in the README

## Testing
- python -m py_compile server.py firebase_db.py

------
https://chatgpt.com/codex/tasks/task_e_68d5db35e66c8324b10ce9321b0ae490