### PR TITLE
Switch backend to Firebase Realtime Database

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Hex Labeler with Sync Backend
 
 This project provides the single-page hex map labeler along with a lightweight
-Python backend that persists map labels to a Google Firestore database. Running
+Python backend that persists map labels to a Firebase Realtime Database. Running
 the server allows multiple clients to share the same map ID and automatically
 keep their labels synchronized across devices.
 
@@ -20,13 +20,18 @@ http://localhost:8000/hex_labeler_webapp_single_file_html_js.html
 
 ### Firebase configuration
 
-The server expects credentials for a Google Cloud project with Firestore
-enabled. Provide the path to a service account JSON key file via the
+The server expects credentials for a Google Cloud project with the Realtime
+Database enabled. Provide the path to a service account JSON key file via the
 `FIREBASE_CREDENTIALS` environment variable. If the variable is not provided the
 server will fall back to Application Default Credentials (ADC).
 
+You must also provide the Realtime Database URL via the
+`FIREBASE_DATABASE_URL` environment variable. This is typically of the form
+`https://<project-id>-default-rtdb.firebaseio.com`.
+
 ```bash
 export FIREBASE_CREDENTIALS="/path/to/service-account.json"
+export FIREBASE_DATABASE_URL="https://<project-id>-default-rtdb.firebaseio.com"
 python server.py
 ```
 

--- a/server.py
+++ b/server.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""HTTP server for the hex labeler web application backed by Google Firebase."""
+"""HTTP server for the hex labeler web app backed by Firebase Realtime Database."""
 
 import json
 import os


### PR DESCRIPTION
## Summary
- replace the Firestore persistence layer with Firebase Realtime Database helpers and initialization
- ensure the HTTP server description reflects the new backend
- document the Realtime Database configuration requirements in the README

## Testing
- python -m compileall server.py firebase_db.py

------
https://chatgpt.com/codex/tasks/task_e_68d5dcc4c3108324889b009846aac723