### PR TITLE
Call Firebase REST API directly from client

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Hex Labeler with Firebase Sync Backend
 
-This project packages a single-page hex-map labeler together with a lightweight
-Python backend that persists map labels to a Firebase Realtime Database. By
-serving the HTML client through the backend, multiple users can connect to the
-same map ID and keep their labels synchronized across devices in near real time.
+This project packages a single-page hex-map labeler that persists map labels
+directly to a Firebase Realtime Database. Multiple users can connect to the
+same map ID and keep their labels synchronized across devices in near real
+time, even when the HTML file is hosted as static content.
 
 ## Prerequisites
 
@@ -14,28 +14,53 @@ same map ID and keep their labels synchronized across devices in near real time.
 
 ## Firebase setup
 
-The backend communicates with Firebase using the public REST API and a database
-secret, so no service account file or `firebase-admin` dependency is required.
-The server ships with defaults that connect to the **osr-hex** Firebase project:
+The web client communicates with Firebase using the public REST API. By default
+it targets the shared **osr-hex** Firebase project:
 
 * **Database URL:** `https://osr-hex-default-rtdb.europe-west1.firebasedatabase.app/`
-* **Database secret:** `jbk2dB7RupFXJitRNlfKST2a2KetiNrwHaIfD77O`
 
-To point the backend at a different Firebase project, override the following
-environment variables before starting the server:
+To point the client at your own Firebase project, define a global configuration
+object before the main script executes. When self-hosting, add the following
+snippet above the inline script block in
+`hex_labeler_webapp_single_file_html_js.html` or inject it from your hosting
+platform:
 
-```bash
-export FIREBASE_DATABASE_URL="https://<project-id>-default-rtdb.firebaseio.com"
-export FIREBASE_DATABASE_SECRET="<database-secret>"
+```html
+<script>
+  window.HEX_LABELER_FIREBASE_CONFIG = {
+    databaseURL: "https://<project-id>-default-rtdb.firebaseio.com",
+    // Optional: supply an auth token when your database rules require it
+    // authToken: "<database-secret-or-custom-token>"
+  };
+</script>
 ```
 
-You can obtain the database secret from the Firebase console by navigating to
-*Project Settings → Service accounts* and expanding the **Database secrets**
-section.
+Ensure your Realtime Database rules allow unauthenticated read/write access (or
+provide a token through `authToken`) for the paths you plan to use, for example:
 
-## Running the server locally
+```json
+{
+  "rules": {
+    "maps": {
+      ".read": true,
+      ".write": true
+    }
+  }
+}
+```
 
-Install dependencies and start the backend:
+> ⚠️ Opening your database to the public means anyone with the URL can read and
+> modify your data. Consider restricting access to specific map IDs, using
+> Firebase Authentication, or serving the app behind your own backend if you
+> need stronger guarantees.
+
+If you prefer to keep the database secret out of the browser, you can still run
+the bundled Python backend described below.
+
+## Running the optional Python proxy
+
+Install dependencies and start the backend if you do not want to expose a
+database secret to the browser or prefer server-side access control:
 
 ```bash
 python server.py
@@ -53,16 +78,18 @@ http://localhost:8000/hex_labeler_webapp_single_file_html_js.html
 * Each map is identified by a `mapId`. Share the same ID with your group to
   collaborate.
 * Labels are stored locally in `localStorage` and synchronized to Firebase when
-  the backend is reachable. The latest server state is fetched when the map is
+  the database is reachable. The latest server state is fetched when the map is
   loaded, falling back to the local cache if necessary.
-* Keep your database secret private and rotate it regularly according to your
-  organization's security policies.
+* When using open database rules, consider choosing opaque map IDs to avoid
+  collisions with other users.
+* Keep your database secret private and rotate it regularly if you rely on an
+  `authToken` or the Python proxy.
 
 ## Troubleshooting
 
 | Symptom | Possible fix |
 | --- | --- |
-| `Permission denied` responses from Firebase | Verify your Realtime Database rules allow access for requests authenticated with the configured database secret and that `FIREBASE_DATABASE_URL` is correct. |
-| Backend fails with credential errors | Ensure the `FIREBASE_DATABASE_SECRET` environment variable is set correctly or that the default secret is still valid. |
-| Web client cannot load data | Ensure you open the HTML file through the backend URL rather than directly from disk, and check that the server process is still running. |
+| `Permission denied` responses from Firebase | Verify your Realtime Database rules allow the requested operation or supply a valid `authToken` in `HEX_LABELER_FIREBASE_CONFIG`. |
+| Updates are not syncing | Confirm that the page is served over `http(s)` (not from the `file://` scheme) so the map image is not treated as cross-origin, and that your Firebase database is reachable. |
+| Prefer not to expose a database secret | Use the bundled Python proxy and keep the secret server-side instead of adding it to `HEX_LABELER_FIREBASE_CONFIG`. |
 

--- a/hex_labeler_webapp_single_file_html_js.html
+++ b/hex_labeler_webapp_single_file_html_js.html
@@ -128,6 +128,8 @@
   </dialog>
 
   <script>
+    // Optional: override the default Firebase database settings before this script runs by defining
+    // `window.HEX_LABELER_FIREBASE_CONFIG = { databaseURL: "https://<your-project>.firebasedatabase.app", authToken?: "<optional-token>" }`.
     // --- Utility: localStorage persistence
     const storageKey = (id) => `hexlabeler:${id}`;
     const remoteSync = createRemoteSync();
@@ -200,6 +202,38 @@
     }
 
     function createRemoteSync() {
+      const firebaseConfig = (() => {
+        const override = window.HEX_LABELER_FIREBASE_CONFIG;
+        if (override && typeof override === 'object' && override.databaseURL) {
+          return {
+            baseUrl: String(override.databaseURL).replace(/\/$/, ''),
+            authToken: override.authToken ? String(override.authToken) : null
+          };
+        }
+        return {
+          baseUrl: 'https://osr-hex-default-rtdb.europe-west1.firebasedatabase.app',
+          authToken: null
+        };
+      })();
+
+      if (!firebaseConfig || !firebaseConfig.baseUrl) {
+        console.warn('Remote sync disabled: no Firebase Realtime Database URL configured.');
+        return {
+          queueSave() {},
+          async load() { return null; }
+        };
+      }
+
+      function buildUrl(id) {
+        const encoded = encodeURIComponent(id);
+        let url = `${firebaseConfig.baseUrl}/maps/${encoded}.json`;
+        if (firebaseConfig.authToken) {
+          const separator = url.includes('?') ? '&' : '?';
+          url = `${url}${separator}auth=${encodeURIComponent(firebaseConfig.authToken)}`;
+        }
+        return url;
+      }
+
       let pending = null;
       let timer = null;
 
@@ -209,13 +243,22 @@
         pending = null;
         timer = null;
         try {
-          await fetch(`/api/maps/${encodeURIComponent(id)}`, {
+          const url = buildUrl(id);
+          const body = JSON.stringify({
+            ...payload,
+            mapId: id,
+            updatedAt: new Date().toISOString()
+          });
+          const res = await fetch(url, {
             method: 'PUT',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify(payload)
+            body
           });
+          if (!res.ok) {
+            throw new Error(`Firebase responded with ${res.status}`);
+          }
         } catch (err) {
-          console.warn('Failed to sync map to server', err);
+          console.warn('Failed to sync map to Firebase', err);
         }
       }
 
@@ -227,12 +270,19 @@
         },
         async load(id) {
           try {
-            const res = await fetch(`/api/maps/${encodeURIComponent(id)}`);
-            if (res.status === 404) return null;
-            if (!res.ok) throw new Error(`Server responded with ${res.status}`);
-            return await res.json();
+            const url = buildUrl(id);
+            const res = await fetch(url, { cache: 'no-store' });
+            if (!res.ok) {
+              if (res.status === 401 || res.status === 403) {
+                console.warn('Firebase denied access to map data. Check your database rules or auth token.');
+              }
+              throw new Error(`Firebase responded with ${res.status}`);
+            }
+            const data = await res.json();
+            if (!data) return null;
+            return data;
           } catch (err) {
-            console.warn('Failed to load map from server', err);
+            console.warn('Failed to load map from Firebase', err);
             return null;
           }
         }


### PR DESCRIPTION
## Summary
- update the web client to sync map data directly to Firebase via the REST API instead of relying on the Python proxy
- allow static hosts to override the Firebase database URL and optional auth token through a global configuration object
- refresh the README with instructions for configuring the client, adjusting database rules, and guidance for static hosting

## Testing
- not run (documentation and frontend changes only)


------
https://chatgpt.com/codex/tasks/task_e_68d5e67869ac8324adfb2cd941154af1