### PR TITLE
Adjust hex grid rotation offset

### DIFF
--- a/hex_labeler_webapp_single_file_html_js.html
+++ b/hex_labeler_webapp_single_file_html_js.html
@@ -619,7 +619,7 @@
     function hexPath(cx, cy, r) {
       const pts = [];
       for (let i = 0; i < 6; i++) {
-        const angle = (Math.PI / 180) * (60 * i + 30);
+        const angle = (Math.PI / 180) * (60 * i - 30);
         const px = cx + r * Math.cos(angle);
         const py = cy + r * Math.sin(angle);
         pts.push(`${px},${py}`);


### PR DESCRIPTION
## Summary
- update the generated SVG hex path to use a flat-top orientation with the correct -30° vertex offset
- align the overlay grid orientation with the underlying map artwork

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d5ee32dc2083248ee5a1983754aae4