### PR TITLE
Refresh README with current project details

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,42 +1,99 @@
-# Hex Labeler with Firebase Sync Backend
+# OSR Hex Labeler
 
-This project packages a single-page hex-map labeler that persists map labels
-directly to a Firebase Realtime Database. Multiple users can connect to the
-same map ID and keep their labels synchronized across devices in near real
-time, even when the HTML file is hosted as static content.
+A single-page hex-map labeling tool for tabletop campaigns. The app lives in
+`index.html` and can be hosted as plain static content. It ships with a blank
+Dolmenwood map but can be pointed at any accessible image and keeps labels in
+sync across browsers through Firebase.
 
-## Prerequisites
+## Highlights
 
-* Python 3.9 or newer.
-* A Google Cloud project with the Firebase Realtime Database enabled (the
-  default configuration in this repository points to the shared **osr-hex**
-  project).
+* **Client-side UI only.** One HTML file contains the UI, styling, and
+  JavaScript required to run the editor.
+* **Grid-aware labels.** Drag the “Drag to add label” chip onto the map to spawn
+  a new marker. The tool analyses the underlying image, snaps labels to the
+  detected hex centres, and lets you fine-tune the overlay scale and offsets.
+* **Persistent map IDs.** Pick a `mapId` to group labels. Data is stored in the
+  browser’s `localStorage` and, when configured, mirrored to Firebase so other
+  devices see the same state.
+* **Import/export.** Back up or migrate maps as JSON and re-import them later to
+  restore labels, settings, and the image reference.
+* **Keyboard- and mouse-friendly.** Drag to pan, scroll to zoom, and edit or
+  delete labels through the modal editor or the `Delete` key.
 
-## Firebase setup
+## Repository layout
 
-The web client communicates with Firebase using the public REST API. By default
-it targets the shared **osr-hex** Firebase project:
+| Path | Description |
+| --- | --- |
+| `index.html` | The complete Hex Labeler application. |
+| `Dolmenwood_Blank_Hex_Map.png` | Default map bundled with the app. Replace it or change the default source in the script to use your own art. |
+| `firebase_db.py` | Helper routines for integrating a Python backend with Firebase if you prefer server-side access. |
+| `data/` | Reserved for future data exports/imports. Empty by default. |
 
-* **Database URL:** `https://osr-hex-default-rtdb.europe-west1.firebasedatabase.app/`
+## Quick start
 
-To point the client at your own Firebase project, define a global configuration
-object before the main script executes. When self-hosting, add the following
-snippet above the inline script block in
-`hex_labeler_webapp_single_file_html_js.html` or inject it from your hosting
-platform:
+1. Serve the repository folder as static files (for example with
+   `python -m http.server 8000`).
+2. Open `http://localhost:8000/index.html` in your browser.
+3. Enter a `mapId` or keep the default (`dolmenwood`). The app will load saved
+   state for that ID from your browser (and Firebase, if enabled).
+
+> Opening the file with the `file://` scheme is supported but some browsers may
+> block features like JSON downloads or cross-origin map images. A local HTTP
+> server is recommended.
+
+## Using your own map art
+
+* Replace `Dolmenwood_Blank_Hex_Map.png` with another image and keep the same
+  filename, **or** edit the initialization call near the bottom of
+  `index.html` to point to a different path/URL.
+* Export a map (`Export JSON`), update the `img.src` field in the JSON to any
+  reachable image, then import it again. The app will load that image and store
+  it with the map record.
+* Align the detected grid using the **Advanced tools** panel: toggle the grid,
+  adjust the scale and offsets, and click **Reset grid adjustments** if you need
+  to revert.
+
+## Firebase synchronisation
+
+The app speaks to Firebase Realtime Database via its REST API. By default it
+points to the shared **osr-hex** project
+(`https://osr-hex-default-rtdb.europe-west1.firebasedatabase.app/`). Data for a
+map lives under `maps/<mapId>` with this shape:
+
+```json
+{
+  "mapId": "dolmenwood",
+  "labels": [
+    { "id": "...", "x": 123.4, "y": 456.7, "hex": "0805", "text": "Label" }
+  ],
+  "options": {
+    "showGrid": true,
+    "gridAdjust": { "scale": 90, "offsetX": 214, "offsetY": 120 }
+  },
+  "imgMeta": {
+    "src": "Dolmenwood_Blank_Hex_Map.png",
+    "naturalWidth": 1700,
+    "naturalHeight": 1200
+  },
+  "updatedAt": "2024-01-01T00:00:00.000Z"
+}
+```
+
+To use your own Firebase project, declare a configuration object before the
+inline script runs:
 
 ```html
 <script>
   window.HEX_LABELER_FIREBASE_CONFIG = {
     databaseURL: "https://<project-id>-default-rtdb.firebaseio.com",
-    // Optional: supply an auth token when your database rules require it
+    // Optional: include an auth token when your database rules require it.
     // authToken: "<database-secret-or-custom-token>"
   };
 </script>
 ```
 
-Ensure your Realtime Database rules allow unauthenticated read/write access (or
-provide a token through `authToken`) for the paths you plan to use, for example:
+Ensure the database rules allow the desired access. A permissive development
+setup might look like:
 
 ```json
 {
@@ -49,47 +106,20 @@ provide a token through `authToken`) for the paths you plan to use, for example:
 }
 ```
 
-> ⚠️ Opening your database to the public means anyone with the URL can read and
-> modify your data. Consider restricting access to specific map IDs, using
-> Firebase Authentication, or serving the app behind your own backend if you
-> need stronger guarantees.
+> ⚠️ Public read/write rules mean anyone with the URL can edit your maps. Use an
+> auth token or tighter rules for production use.
 
-If you prefer to keep the database secret out of the browser, you can still run
-the bundled Python backend described below.
+## Tips and troubleshooting
 
-## Running the optional Python proxy
-
-Install dependencies and start the backend if you do not want to expose a
-database secret to the browser or prefer server-side access control:
-
-```bash
-python server.py
-```
-
-The server listens on port 8000 by default. Once it is running, load the web
-client through the backend so that API calls are proxied correctly:
-
-```
-http://localhost:8000/hex_labeler_webapp_single_file_html_js.html
-```
-
-## Usage tips
-
-* Each map is identified by a `mapId`. Share the same ID with your group to
-  collaborate.
-* Labels are stored locally in `localStorage` and synchronized to Firebase when
-  the database is reachable. The latest server state is fetched when the map is
-  loaded, falling back to the local cache if necessary.
-* When using open database rules, consider choosing opaque map IDs to avoid
-  collisions with other users.
-* Keep your database secret private and rotate it regularly if you rely on an
-  `authToken` or the Python proxy.
-
-## Troubleshooting
-
-| Symptom | Possible fix |
+| Issue | Suggested fix |
 | --- | --- |
-| `Permission denied` responses from Firebase | Verify your Realtime Database rules allow the requested operation or supply a valid `authToken` in `HEX_LABELER_FIREBASE_CONFIG`. |
-| Updates are not syncing | Confirm that the page is served over `http(s)` (not from the `file://` scheme) so the map image is not treated as cross-origin, and that your Firebase database is reachable. |
-| Prefer not to expose a database secret | Use the bundled Python proxy and keep the secret server-side instead of adding it to `HEX_LABELER_FIREBASE_CONFIG`. |
+| Firebase calls fail with `Permission denied`. | Check your Realtime Database rules or provide an `authToken` in `HEX_LABELER_FIREBASE_CONFIG`. |
+| The map never loads. | Confirm the image path/URL is reachable from the browser and serve the app over HTTP(S) rather than `file://`. |
+| Labels stop syncing between devices. | Verify the devices use the same `mapId`, have network access to Firebase, and that no conflicting JSON imports overwrote data. |
+| Grid overlay is misaligned. | Use the advanced controls to tweak scale and offsets or reset them to the defaults. |
 
+## Extending the project
+
+The `firebase_db.py` module contains thin wrappers around the Firebase REST API
+for Python. You can build a proxy service with it when you prefer to hide your
+Firebase credentials from the browser or need to enforce server-side policies.


### PR DESCRIPTION
## Summary
- rewrite the README to describe the current single-page hex labeler and its capabilities
- document how to host the app, swap in custom map art, and configure Firebase synchronisation
- add troubleshooting guidance and notes about the included helper scripts

## Testing
- not run (documentation-only change)

------
https://chatgpt.com/codex/tasks/task_e_68d686fdcf4483248ff9122f7329cf4a