### PR TITLE
Adjust icon vertical positioning within hex markers

### DIFF
--- a/index.html
+++ b/index.html
@@ -529,7 +529,8 @@
       const textMarkup = textLines.map((line, idx) => `
         <text class="icon-label" x="50" y="${110 + idx * 18}" font-size="18">${escapeHtml(line)}</text>
       `).join('');
-      return `<g class="map-item icon" data-id="${l.id}" data-icon="${icon.id}" transform="translate(${l.x},${l.y}) scale(${scale}) translate(-50,-50)">${icon.svg}${textMarkup}</g>`;
+      const yOffset = hasContent ? 64 : 54;
+      return `<g class="map-item icon" data-id="${l.id}" data-icon="${icon.id}" transform="translate(${l.x},${l.y}) scale(${scale}) translate(-50,-${yOffset})">${icon.svg}${textMarkup}</g>`;
     }
 
     function updateEditorMode(mode) {


### PR DESCRIPTION
## Summary
- raise icon markers that include text so they sit higher within each hex for better visual balance

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d6f9cdf93483249e83fa6c088ac361