### PR TITLE
Prefer icon text for label list titles

### DIFF
--- a/index.html
+++ b/index.html
@@ -761,7 +761,9 @@
         const hex = (l.hex || '').trim();
         const iconName = l.kind === 'icon' ? (ICON_LOOKUP[l.iconId]?.label || l.iconId || 'Icon') : '';
         const firstLine = (l.text || '').split('\n').map(part => part.trim()).find(Boolean) || '';
-        const title = l.kind === 'icon' ? iconName : (firstLine || 'Untitled label');
+        const title = l.kind === 'icon'
+          ? (firstLine || iconName)
+          : (firstLine || 'Untitled label');
         const haystack = `${hex} ${iconName} ${l.text || ''}`.toLowerCase();
         if (filterText && !haystack.includes(filterText)) {
           continue;


### PR DESCRIPTION
## Summary
- update label list title generation to favor custom text on icon entries while keeping existing text label behavior
- retain HTML escaping when displaying label titles

## Testing
- No tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d733cedf208324821cc41e08dce74e