### PR TITLE
Show icon metadata in label filter list

### DIFF
--- a/index.html
+++ b/index.html
@@ -770,7 +770,7 @@
         }
         const hexDisplay = hex ? escapeHtml(hex) : '—';
         const titleDisplay = title ? escapeHtml(title) : 'Untitled label';
-        const kindLabel = l.kind === 'icon' ? 'Icon' : 'Text';
+        const kindLabel = l.kind === 'icon' ? (iconName || 'Icon') : 'Text';
         entries.push(`
           <button type="button" class="label-list-item${selectedId === l.id ? ' is-active' : ''}" data-id="${l.id}">
             <span class="label-list-hex">${hexDisplay}</span>


### PR DESCRIPTION
## Summary
- display the icon's text caption in the label filter list
- show the selected icon type name instead of the generic "Icon" label

## Testing
- Not run

------
https://chatgpt.com/codex/tasks/task_e_68d735be1a308324acb63ed92b222862