### PR TITLE
Center party icon glyph

### DIFF
--- a/index.html
+++ b/index.html
@@ -596,6 +596,13 @@
           <path d="M50 34v48" />
           <path d="M34 62h20" />
         `
+      },
+      {
+        id: 'party',
+        label: 'Party',
+        svg: `
+          <text x="50" y="50" font-size="64" dominant-baseline="middle" text-anchor="middle">℗</text>
+        `
       }
     ];
 


### PR DESCRIPTION
## Summary
- adjust the Party icon SVG to center the ℗ glyph within its viewbox

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d9adae651c8324bf7a9f2a18faab9f